### PR TITLE
fix: add fallback url to MY_IMG_DIR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 ANALYTICS_ID=ABC123456
-VITE_IMG_DIR=https://your-website.com/images
+VITE_IMG_DIR=https://flowbite-admin-dashboard.vercel.app/images

--- a/src/lib/variables.ts
+++ b/src/lib/variables.ts
@@ -1,8 +1,5 @@
-export const MY_IMG_DIR = import.meta.env.VITE_IMG_DIR;
+export const MY_IMG_DIR = import.meta.env.VITE_IMG_DIR ?? 'https://flowbite-admin-dashboard.vercel.app/images';
 
-if (!MY_IMG_DIR) {
-  throw new Error('VITE_IMG_DIR environment variable is required. Please add it to your .env file.');
-}
 /**
  * Constructs a path to an avatar image
  * @param src The avatar image filename


### PR DESCRIPTION
Add 'https://flowbite-admin-dashboard.vercel.app/images' fallback to `const MY_IMG_DIR`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image asset directory configuration to include a sensible default fallback URL. The application now handles missing environment variables gracefully with built-in defaults, streamlining the initial setup process and allowing the app to function properly without explicit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->